### PR TITLE
(BOLT-1021) Exit 1 on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.1.3
+
+**Fixed**
+- Task now uses exit code 1 when exiting due to an exception.
+
 ## Release 0.1.2
 
 **Fixed**

--- a/lib/task_helper.py
+++ b/lib/task_helper.py
@@ -31,6 +31,7 @@ class TaskHelper:
             print(json.dumps(output))
         except TaskError as err:
             print(json.dumps(err.to_hash()))
+            exit(1)
         except Exception as err:
             print(json.dumps({
                 'kind': 'python.task.helper/exception',
@@ -38,3 +39,4 @@ class TaskHelper:
                 'msg': err.__str__(),
                 'details': { 'class': err.__class__.__name__ }
             }))
+            exit(1)

--- a/lib/test_task_helper.py
+++ b/lib/test_task_helper.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 import sys
 import unittest
 from task_helper import TaskHelper, TaskError
@@ -35,7 +36,9 @@ class TestHelper(unittest.TestCase):
         stub_stdouts(self)
         class MyTask(TaskHelper):
             pass
-        MyTask().run()
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            MyTask().run()
+            assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
             'kind': 'python.task.helper/exception',
@@ -50,7 +53,9 @@ class TestHelper(unittest.TestCase):
         class MyTask(TaskHelper):
             def task(self, args):
                 raise Exception('does not work')
-        MyTask().run()
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            MyTask().run()
+            assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
             'kind': 'python.task.helper/exception',
@@ -65,7 +70,9 @@ class TestHelper(unittest.TestCase):
         class MyTask(TaskHelper):
             def task(self, args):
                 raise TaskError('a task error', 'mytask/failed', {'any': 'thing'})
-        MyTask().run()
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            MyTask().run()
+            assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
             'kind': 'mytask/failed',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Puppet, Inc.",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",


### PR DESCRIPTION
When an exception is thrown, exit(1) to indicate that the task failed. Previously a task that errored would still appear to be successful.