### PR TITLE
(maint) Prep for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Changed**
+- Helper files should go in the `files` directory of a module to prevent them from being added to the puppet ruby loadpath or seen as tasks.
+
 ## Release 0.1.3
 
 **Fixed**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",


### PR DESCRIPTION
Breaking change due to refactoring directory structure bumps the major version.