### PR TITLE
Wrap errors in _error key

### DIFF
--- a/files/task_helper.py
+++ b/files/task_helper.py
@@ -11,9 +11,10 @@ class TaskError(Exception):
         self.issue_code = issue_code
 
     def to_hash(self):
-        result = { 'kind': self.kind, 'msg': self.__str__(), 'details': self.details }
+        error_hash = { 'kind': self.kind, 'msg': self.__str__(), 'details': self.details }
         if self.issue_code:
-            result['issue_code'] = self.issue_code
+            error_hash['issue_code'] = self.issue_code
+        result = { '_error': error_hash }
         return result
 
 class TaskHelper:
@@ -33,10 +34,11 @@ class TaskHelper:
             print(json.dumps(err.to_hash()))
             exit(1)
         except Exception as err:
-            print(json.dumps({
+            error_hash = {
                 'kind': 'python.task.helper/exception',
                 'issue_code': 'EXCEPTION',
                 'msg': err.__str__(),
                 'details': { 'class': err.__class__.__name__ }
-            }))
+            }
+            print(json.dumps({ '_error': error_hash }))
             exit(1)

--- a/files/test_task_helper.py
+++ b/files/test_task_helper.py
@@ -41,10 +41,12 @@ class TestHelper(unittest.TestCase):
             assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
-            'kind': 'python.task.helper/exception',
-            'issue_code': 'EXCEPTION',
-            'msg': 'TaskHelper.task is not implemented',
-            'details': {}
+            '_error': {
+                'kind': 'python.task.helper/exception',
+                'issue_code': 'EXCEPTION',
+                'msg': 'TaskHelper.task is not implemented',
+                'details': {}
+            }
         })
 
     def test_error_method(self):
@@ -58,10 +60,12 @@ class TestHelper(unittest.TestCase):
             assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
-            'kind': 'python.task.helper/exception',
-            'issue_code': 'EXCEPTION',
-            'msg': 'does not work',
-            'details': { 'class': 'Exception' }
+            '_error': {
+                'kind': 'python.task.helper/exception',
+                'issue_code': 'EXCEPTION',
+                'msg': 'does not work',
+                'details': { 'class': 'Exception' }
+            }
         })
 
     def test_task_error(self):
@@ -75,9 +79,11 @@ class TestHelper(unittest.TestCase):
             assert pytest_wrapped_e.value.code == 1
         result = json.loads(sys.stdout.getvalue())
         self.assertEqual(result, {
-            'kind': 'mytask/failed',
-            'msg': 'a task error',
-            'details': {'any': 'thing'}
+            '_error': {
+                'kind': 'mytask/failed',
+                'msg': 'a task error',
+                'details': {'any': 'thing'}
+            }
         })
 
     def test_echo_method(self):


### PR DESCRIPTION
Previously, the task helper would rescue errors in the run method and
simply print their hashified version. This caused Bolt to synthesize its own
_error object (simply stating the task failed and its exit code) which
took precedence over the actual underlying cause.

We now properly wrap the result in _error so Bolt knows that it should
display that information to the user.

Porting over the changes from puppetlabs/puppetlabs-ruby_task_helper#5