### PR TITLE
Add 'debug' and 'debug_statements' methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,46 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.4.0
+
+### New features
+
+- Added a `debug` method to add debugging statements to the `details` field of a `TaskError`.
+
+- Added a `debug_statements` method to retrieve the current list of debugging statements.
+
 ## Release 0.3.0
 
-**Fixed**
+### Bug fixes
 
-Previously error hashes were not wrapped under an `_error` key causing bolt to ignore underlying error message. Now error hashes are wrapped under the expected `_error` key.
+- Previously error hashes were not wrapped under an `_error` key causing bolt to ignore underlying error message. Now error hashes are wrapped under the expected `_error` key.
 
 ## Release 0.2.0
 
-**Changed**
+### Changes
+
 - Helper files should go in the `files` directory of a module to prevent them from being added to the puppet ruby loadpath or seen as tasks.
 
 ## Release 0.1.3
 
-**Fixed**
+### Bug fixes
+
 - Task now uses exit code 1 when exiting due to an exception.
 
 ## Release 0.1.2
 
-**Fixed**
+### Bug fixes
+
 - Fix module metadata to include required keys.
 
 ## Release 0.1.1
 
-**Fixed**
+### Bug fixes
+
 - Fix packaging so automation to ship the module to the Forge works.
 
 ## Release 0.1.0
 
-**Features**
+### New features
+
 - Initial release of TaskHelper class to assist with writing Puppet Tasks in Python.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Python helper library for use by [Puppet Tasks](https://puppet.com/docs/bolt/1
 1. [Requirements](#requirements)
 1. [Setup](#setup)
 1. [Usage](#usage)
+1. [Debugging](#debugging)
 
 ## Description
 
@@ -64,4 +65,26 @@ You can additionally provide detailed errors by raising a `TaskError`, such as
 class MyTask(TaskHelper):
     def task(self, args):
         raise TaskError('my task errored', 'mytask/error_kind', {'location': 'task entry'})
+```
+
+## Debugging
+
+When writing your task, it can be helpful to write debugging statements to locate
+the source of any errors. The library includes a `debug` method that accepts arbitrary
+values and logs it as a debugging statement. If the task errors, the list of
+debugging statements will be included in the resulting error message.
+
+The list of debugging statements can also be accessed from the task itself by accessing
+the `debug_statements` attribute. This can be used to include the debugging statements in
+a `TaskError` that you explicitly raise.
+
+Adding a debugging statement:
+```python
+self.debug('Result of method call: {}'.format(result))
+```
+Adding the list of debugging statements to a `TaskError`:
+```python
+raise TaskError('my task error message',
+                'mytask/error-kind',
+                { 'debug': self.debug_statements })
 ```

--- a/files/task_helper.py
+++ b/files/task_helper.py
@@ -18,6 +18,12 @@ class TaskError(Exception):
         return result
 
 class TaskHelper:
+    def __init__(self):
+        self.debug_statements = []
+
+    def debug(self, statement):
+        self.debug_statements.append(statement)
+
     def task(self, args):
         raise TaskError(
             'TaskHelper.task is not implemented',
@@ -38,7 +44,10 @@ class TaskHelper:
                 'kind': 'python.task.helper/exception',
                 'issue_code': 'EXCEPTION',
                 'msg': err.__str__(),
-                'details': { 'class': err.__class__.__name__ }
+                'details': {
+                    'class': err.__class__.__name__,
+                    'debug': self.debug_statements
+                }
             }
             print(json.dumps({ '_error': error_hash }))
             exit(1)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Puppet, Inc.",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",


### PR DESCRIPTION
This adds two helper methods to the task helper.

**debug**

This method logs arbitrary values as debugging statements that are added
under the `details` field when a `TaskError` is raised.

**debug_statements**

This method returns the current list of debugging statements.