### PR TITLE
(maint) Remove virtualenv from tarball

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.4.0",
-  "author": "Puppet, Inc.",
+  "version": "0.4.2",
+  "author": "puppetlabs",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-python_task_helper",


### PR DESCRIPTION
Version 0.4.0 on the forge contained a virtualenv in the tarball from a
manual release. This creates a new release, which allows us to publish a
new tarball without a virtualenv.