### PR TITLE
(maint) Add .bundle to gitignore and prep for 0.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 
 # Ruby Gemfile
 Gemfile.lock
+.bundle/

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "puppetlabs",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",


### PR DESCRIPTION
When building the module for publishing, Jenkins will install necessary
gems to `puppetlabs-python_task_helper/.bundle/` and if that directory
is not ignored will build the module tarball with `.bundle/` in it. This
adds `.bundle/` to the gitignore so it isn't included in module builds
(and isn't added to the git repo).