### PR TITLE
(maint) Bump maximum Puppet version to include 7.x, prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.5.0
+
+### New features
+
+- Bump maximum Puppet version to include 7.x
+
 ## Release 0.4.0
 
 ### New features

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "author": "puppetlabs",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.7.1",


### PR DESCRIPTION
This bumps the maximum Puppet version to include the 7.x series, and
preps to release with the change.