### PR TITLE
(maint) Release prep for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.6.0
+
+## New features
+
+- Bump maximum Puppet version to include 8.x
+
+## Changes
+
+- Updated module with `PDK update` to ensure it consumes current templates
+
 ## Release 0.5.0
 
 ### New features

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-python_task_helper",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "puppetlabs",
   "summary": "A Python helper library for use by Puppet Tasks",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release prep for v0.6.0 including a PDK update and a Puppet bump to include Puppet 8 compatibility. Module tested locally, tests green.